### PR TITLE
Make adapter an environment parameter

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/hubot --adapter slack
+web: bin/hubot --adapter $HUBOT_ADAPTER


### PR DESCRIPTION
This commit allows us to change the adapter to whatever we feel is appropriate for our chat service.
